### PR TITLE
Fix work with json extension.

### DIFF
--- a/Appenders/CloudWatchLogsAppender/Parsers/LogsEventMessageParser.cs
+++ b/Appenders/CloudWatchLogsAppender/Parsers/LogsEventMessageParser.cs
@@ -64,9 +64,6 @@ namespace AWSAppender.CloudWatchLogs.Parsers
             {
                 case "message":
                 case "__cav_rest":
-                    if (!string.IsNullOrEmpty(_currentDatum.Message))
-                        break;
-
                     _currentDatum.Message = DefaultsOverridePattern ? DefaultMessage ?? value.sValue : value.sValue;
                     break;
 


### PR DESCRIPTION
The list of AppenderValue contains simple message string and rendered json string (log4net.ext.json).

If _currentDatum.Message already contains the simple message, then rendered string will be ignored.

This check deleted for correct work with json log message.